### PR TITLE
fix: hard set preference boundary in xml

### DIFF
--- a/breeze-app/app/src/main/res/xml/preferences.xml
+++ b/breeze-app/app/src/main/res/xml/preferences.xml
@@ -18,25 +18,33 @@
         <SeekBarPreference
             app:key="temperature"
             app:title="@string/pref_temperature_title"
-            app:summary="@string/pref_temperature_summary" />
+            app:summary="@string/pref_temperature_summary"
+            android:min="0"
+            android:max="100"/>
 
         <!-- Max Token -->
         <SeekBarPreference
             app:key="max_token_value"
             app:title="@string/pref_max_token_title"
-            app:summary="@string/pref_max_token_summary" />
+            app:summary="@string/pref_max_token_summary"
+            android:min="128"
+            android:max="2048" />
 
         <!-- Repetition Penalty -->
         <SeekBarPreference
             app:key="repetition_penalty"
             app:title="@string/pref_repetition_penalty_title"
-            app:summary="@string/pref_repetition_penalty_summary" />
+            app:summary="@string/pref_repetition_penalty_summary"
+            android:min="100"
+            android:max="200" />
 
         <!-- Frequency Penalty -->
         <SeekBarPreference
             app:key="frequency_penalty"
             app:title="@string/pref_frequency_penalty_title"
-            app:summary="@string/pref_frequency_penalty_summary" />
+            app:summary="@string/pref_frequency_penalty_summary"
+            android:min="100"
+            android:max="200" />
 
         <!-- integer number input field -->
         <EditTextPreference
@@ -49,7 +57,9 @@
         <SeekBarPreference
             app:key="top_p"
             app:title="@string/pref_top_p_title"
-            app:summary="@string/pref_top_p_summary" />
+            app:summary="@string/pref_top_p_summary"
+            android:min="0"
+            android:max="100" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Boundary values (min/max) must be set in XML. Android uses them to validate input and ignores runtime changes. Out-of-range values are clamped to the min.