### PR TITLE
Fix setting value forget

### DIFF
--- a/breeze-app/app/build.gradle.kts
+++ b/breeze-app/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.mtkresearch.breezeapp"
         minSdk = 33
         targetSdk = 35
-        versionCode = 19
-        versionName = "1.0.5"
+        versionCode = 20
+        versionName = "1.0.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/utils/SettingsFragment.java
+++ b/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/utils/SettingsFragment.java
@@ -79,9 +79,6 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        // Fix corrupted preferences first
-        fixCorruptedPreferences();
-        
         super.onCreate(savedInstanceState);
         // Apply our custom theme
         getContext().getTheme().applyStyle(R.style.PreferenceThemeOverlay_BreezeApp, true);
@@ -137,6 +134,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     @SuppressLint("DefaultLocale")
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        fixCorruptedPreferences();
         setPreferencesFromResource(R.xml.preferences, rootKey);
 
         // 只在第一次進入設定時寫入 default 值，之後用戶調整不會被覆蓋

--- a/breeze-app/app/src/main/res/xml/preferences.xml
+++ b/breeze-app/app/src/main/res/xml/preferences.xml
@@ -18,25 +18,33 @@
         <SeekBarPreference
             app:key="temperature"
             app:title="@string/pref_temperature_title"
-            app:summary="@string/pref_temperature_summary" />
+            app:summary="@string/pref_temperature_summary"
+            android:min="0"
+            android:max="100"/>
 
         <!-- Max Token -->
         <SeekBarPreference
             app:key="max_token_value"
             app:title="@string/pref_max_token_title"
-            app:summary="@string/pref_max_token_summary" />
+            app:summary="@string/pref_max_token_summary"
+            android:min="128"
+            android:max="2048" />
 
         <!-- Repetition Penalty -->
         <SeekBarPreference
             app:key="repetition_penalty"
             app:title="@string/pref_repetition_penalty_title"
-            app:summary="@string/pref_repetition_penalty_summary" />
+            app:summary="@string/pref_repetition_penalty_summary"
+            android:min="100"
+            android:max="200" />
 
         <!-- Frequency Penalty -->
         <SeekBarPreference
             app:key="frequency_penalty"
             app:title="@string/pref_frequency_penalty_title"
-            app:summary="@string/pref_frequency_penalty_summary" />
+            app:summary="@string/pref_frequency_penalty_summary"
+            android:min="100"
+            android:max="200" />
 
         <!-- integer number input field -->
         <EditTextPreference
@@ -49,7 +57,9 @@
         <SeekBarPreference
             app:key="top_p"
             app:title="@string/pref_top_p_title"
-            app:summary="@string/pref_top_p_summary" />
+            app:summary="@string/pref_top_p_summary"
+            android:min="0"
+            android:max="100" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
- Boundary values (min/max) must be set in XML. Android uses them to validate input and ignores runtime changes. Out-of-range values are clamped to the min.

(extra)
- move fixCorruptedPreferences() to onCreatePreferences instead of onCreate() to prevent null object issues during initialization.