### PR TITLE
fix: add new model type Breeze to apply custom template

### DIFF
--- a/breeze-app/app/build.gradle.kts
+++ b/breeze-app/app/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.mtkresearch.breezeapp"
         minSdk = 33
         targetSdk = 35
-        versionCode = 20
-        versionName = "1.0.6"
+        versionCode = 22
+        versionName = "1.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/breeze-app/app/src/main/java/com/executorch/ModelType.java
+++ b/breeze-app/app/src/main/java/com/executorch/ModelType.java
@@ -14,4 +14,5 @@ public enum ModelType {
   LLAMA_3_2,
   LLAVA_1_5,
   LLAMA_GUARD_3,
+  BREEZE_2
 }

--- a/breeze-app/app/src/main/java/com/executorch/ModelUtils.java
+++ b/breeze-app/app/src/main/java/com/executorch/ModelUtils.java
@@ -22,6 +22,7 @@ public class ModelUtils {
       case LLAMA_3:
       case LLAMA_3_1:
       case LLAMA_3_2:
+      case BREEZE_2:
       default:
         return TEXT_MODEL;
     }

--- a/breeze-app/app/src/main/java/com/executorch/PromptFormat.java
+++ b/breeze-app/app/src/main/java/com/executorch/PromptFormat.java
@@ -22,6 +22,7 @@ public class PromptFormat {
       case LLAMA_3:
       case LLAMA_3_1:
       case LLAMA_3_2:
+      case BREEZE_2:
         return "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
             + SYSTEM_PLACEHOLDER
             + "<|eot_id|>";
@@ -42,7 +43,11 @@ public class PromptFormat {
             + USER_PLACEHOLDER
             + "<|eot_id|>"
             + "<|start_header_id|>assistant<|end_header_id|>";
-
+      case BREEZE_2:
+        return "<|start_header_id|>user<|end_header_id|>\n"
+            + USER_PLACEHOLDER
+            + "<|eot_id|>"
+            + "<|start_header_id|>assistant<|end_header_id|>\n\n";
       case LLAVA_1_5:
       default:
         return USER_PLACEHOLDER;
@@ -54,6 +59,7 @@ public class PromptFormat {
       case LLAMA_3:
       case LLAMA_3_1:
       case LLAMA_3_2:
+      case BREEZE_2:
         return getUserPromptTemplate(modelType) + "\n" + ASSISTANT_PLACEHOLDER + "<|eot_id|>";
       case LLAVA_1_5:
         return USER_PLACEHOLDER + " ASSISTANT:";
@@ -67,8 +73,8 @@ public class PromptFormat {
       case LLAMA_3:
       case LLAMA_3_1:
       case LLAMA_3_2:
-        return "<|end_of_text|>";
       case LLAMA_GUARD_3:
+      case BREEZE_2:
         return "<|eot_id|>";
       case LLAVA_1_5:
         return "</s>";

--- a/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/ChatActivity.java
+++ b/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/ChatActivity.java
@@ -1778,7 +1778,7 @@ public class ChatActivity extends AppCompatActivity implements ChatMessageAdapte
     private String getFormattedPrompt(String userMessage) {
         // If history lookback is 1, only use system prompt + current message
         if (AppConstants.CONVERSATION_HISTORY_LOOKBACK == 1) {
-            return PromptManager.formatCompletePrompt(userMessage, new ArrayList<>(), ModelType.LLAMA_3_2);
+            return PromptManager.formatCompletePrompt(userMessage, new ArrayList<>(), ModelType.BREEZE_2);
         }
         
         // Otherwise use history as before
@@ -1796,13 +1796,13 @@ public class ChatActivity extends AppCompatActivity implements ChatMessageAdapte
         }
         
         // Format with history
-        String fullPrompt = PromptManager.formatCompletePrompt(userMessage, historyMessages, ModelType.LLAMA_3_2);
+        String fullPrompt = PromptManager.formatCompletePrompt(userMessage, historyMessages, ModelType.BREEZE_2);
         
         // Check if prompt might exceed max length (using conservative estimate)
         if (fullPrompt.length() > AppConstants.getLLMMaxInputLength(this) * 3) { // Assuming average of 3 chars per token
             Log.w(TAG, "Prompt too long with history, removing history to fit token limit");
             // Format prompt with empty history list to get just system prompt + user message
-            String reducedPrompt = PromptManager.formatCompletePrompt(userMessage, new ArrayList<>(), ModelType.LLAMA_3_2);
+            String reducedPrompt = PromptManager.formatCompletePrompt(userMessage, new ArrayList<>(), ModelType.BREEZE_2);
             Log.d(TAG, "Reduced prompt without history: " + reducedPrompt);
             return reducedPrompt;
         }

--- a/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/service/LLMEngineService.java
+++ b/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/service/LLMEngineService.java
@@ -364,7 +364,7 @@ public class LLMEngineService extends BaseEngineService {
                     
                     Log.d(TAG, "Init CPU LlamaModule with temperature: " + temperature);
                     mModule = new LlamaModule(
-                        ModelUtils.getModelCategory(ModelType.LLAMA_3_2),
+                        ModelUtils.getModelCategory(ModelType.BREEZE_2),
                         model_entry_path,
                         Paths.get(modelBasePath, "tokenizer.bin").toString(),
                         temperature
@@ -505,7 +505,7 @@ public class LLMEngineService extends BaseEngineService {
                                         }
 
                                         // Handle both stop tokens - filter out both EOS tokens
-                                        if (token.equals(PromptFormat.getStopToken(ModelType.LLAMA_3_2)) || token.equals("<|eot_id|>")) {
+                                        if (token.equals(PromptFormat.getStopToken(ModelType.BREEZE_2))) {
                                             Log.d(TAG, "Stop token detected: " + token);
                                             String finalResponse = currentStreamingResponse.toString();
                                             if (!currentResponse.isDone()) {

--- a/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/utils/ModelUtils.java
+++ b/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/utils/ModelUtils.java
@@ -63,10 +63,12 @@ public class ModelUtils {
     public static com.executorch.ModelType getModelType(String modelPath) {
         String modelName = getModelNameFromPath(modelPath).toLowerCase();
         // Both Breeze and Llama models will use LLAMA_3_2 since BREEZE_2 is not available
-        if (modelName.contains("llama") || modelName.contains("breeze")) {
+        if (modelName.contains("llama")) {
             return com.executorch.ModelType.LLAMA_3_2;
+        } else if (modelName.contains("breeze")) {
+            return com.executorch.ModelType.BREEZE_2;
         }
-        return com.executorch.ModelType.LLAMA_3_2; // Default to LLAMA_3_2
+        return com.executorch.ModelType.BREEZE_2; // Default to LLAMA_3_2
     }
 
     /**


### PR DESCRIPTION
- Breeze2’s prompt format differs from the Llama format by requiring an extra "\n\n" at the end.