### PR TITLE
fix: ClassCastException in MainActivity after closing the SettingsActivity  #98

### DIFF
--- a/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/MainActivity.java
+++ b/breeze-app/app/src/main/java/com/mtkresearch/breezeapp/MainActivity.java
@@ -420,7 +420,7 @@ public class MainActivity extends AppCompatActivity {
             intent.putExtra("model_path", LLAMA_MODEL_PATH + selectedLlmModel);
             // Add backend preference and temperature for LLM service
             String savedBackend = settings.getString(AppConstants.KEY_PREFERRED_BACKEND, "cpu");
-            float savedTemp = settings.getFloat(AppConstants.KEY_TEMPERATURE, 0.0f);
+            float savedTemp = settings.getFloat(AppConstants.KEY_TEMPERATURE_VALUE, 0.0f);
             intent.putExtra("preferred_backend", savedBackend);
             intent.putExtra("temperature", savedTemp);
             Log.d(TAG, "Starting LLM service with backend: " + savedBackend + ", temperature: " + savedTemp);
@@ -704,7 +704,7 @@ public class MainActivity extends AppCompatActivity {
         backendSpinner.setAdapter(backendAdapter);
 
         // Load saved settings
-        float savedTemp = settings.getFloat(AppConstants.KEY_TEMPERATURE, 0.0f);
+        float savedTemp = settings.getFloat(AppConstants.KEY_TEMPERATURE_VALUE, 0.0f);
         String savedBackend = settings.getString(AppConstants.KEY_PREFERRED_BACKEND, AppConstants.DEFAULT_BACKEND);
         
         temperatureInput.setText(String.valueOf(savedTemp));
@@ -729,7 +729,7 @@ public class MainActivity extends AppCompatActivity {
                 try {
                     float temp = s.length() > 0 ? Float.parseFloat(s.toString()) : 0.0f;
                     if (temp >= 0.0f && temp <= 2.0f) {
-                        settings.edit().putFloat(AppConstants.KEY_TEMPERATURE, temp).apply();
+                        settings.edit().putFloat(AppConstants.KEY_TEMPERATURE_VALUE, temp).apply();
                     }
                 } catch (NumberFormatException e) {
                     Log.w(TAG, "Invalid temperature value");


### PR DESCRIPTION
After closing the SettingsActivity, the property value KEY_TEMPERATURE (Integer) will be set in SharedPreferences.
From then on, MainActivity will get the ClassCastException while retrieving the AppConstants.KEY_TEMPERATURE by getFloat().


![截圖 2025-06-12 上午10 33 22](https://github.com/user-attachments/assets/597c0b7f-d757-41b2-bdc5-cae9c7bee9e2)
