### PR TITLE
get the correct error string and show the dialog if the llm is not ready

### DIFF
--- a/breeze-app/app/src/main/res/values-zh-rTW/strings.xml
+++ b/breeze-app/app/src/main/res/values-zh-rTW/strings.xml
@@ -344,6 +344,8 @@
     <string name="LLM_empty_response_error">很抱歉，無法生成適當的回應。請嘗試重新表述您的問題。</string>
     <string name="LLM_input_too_long_error">很抱歉，您的輸入太長。請嘗試將其分成較小的部分。</string>
     <string name="LLM_invalid_token_error">### 因ExecuTorch已知問題，導致語言模型無法針對上述內容進行回應 ###</string>
+    <string name="llm_not_ready_title">模型未準備就緒</string>
+    <string name="llm_not_ready_message">語言模型仍在初始化中。請稍候再試。</string>
     <string name="error_binding_services">服務綁定失敗</string>
 
     <!-- New error messages for ChatActivity -->

--- a/breeze-app/app/src/main/res/values/strings.xml
+++ b/breeze-app/app/src/main/res/values/strings.xml
@@ -350,6 +350,8 @@
     <string name="LLM_empty_response_error">I apologize, but I couldn\'t generate a proper response. Please try rephrasing your question.</string>
     <string name="LLM_input_too_long_error">I apologize, but your input is too long. Please try breaking it into smaller parts.</string>
     <string name="LLM_invalid_token_error">### Due to known ExecuTorch issues, the language model is unable to respond to the above content ###</string>
+    <string name="llm_not_ready_title">Model Not Ready</string>
+    <string name="llm_not_ready_message">The language model is still initializing. Please wait a moment and try again.</string>
     <string name="error_binding_services">Fail to bind services</string>
 
     <!-- New error messages for ChatActivity -->

--- a/breeze-app/app/src/service/java/com/mtkresearch/breezeapp/service/LLMEngineService.java
+++ b/breeze-app/app/src/service/java/com/mtkresearch/breezeapp/service/LLMEngineService.java
@@ -411,10 +411,11 @@ public class LLMEngineService extends BaseEngineService {
 
     public CompletableFuture<String> generateStreamingResponse(String prompt, LLMInferenceParams params, StreamingResponseCallback callback) {
         if (!isInitialized) {
+            String errorMsg = context.getString(R.string.LLM_default_error);
             if (callback != null) {
-                callback.onToken(String.valueOf(R.string.LLM_default_error));
+                callback.onToken(errorMsg);
             }
-            return CompletableFuture.completedFuture(String.valueOf(R.string.LLM_default_error));
+            return CompletableFuture.completedFuture(errorMsg);
         }
 
         hasSeenAssistantMarker = false;


### PR DESCRIPTION
- Fixed the incorrect method used to retrieve string resources for error messages.
- Added a warning dialog to notify users when they attempt to send a message before the LLM has finished initializing.